### PR TITLE
Release 0.9.20

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,10 @@ PR for version
 
 # Details
 
+## `Additions`
+
+* [commit hash] commit summary
+
 ## `Changes`
 
 * [commit hash] commit summary

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+PR for version
+
+# Summary
+
+# Details
+
+## `Changes`
+
+* [commit hash] commit summary
+
+## `Fixes`
+
+* [commit hash] commit summary

--- a/envs/pandas.yml
+++ b/envs/pandas.yml
@@ -1,0 +1,5 @@
+name: pandas
+channels:
+- conda-forge
+dependencies:
+- pandas>=2.2.2

--- a/envs/python.yml
+++ b/envs/python.yml
@@ -1,5 +1,5 @@
-name: Python2
+name: python
 channels:
 - conda-forge
 dependencies:
-- python=2.7.15
+- python=3.12.3

--- a/envs/rdp_classifier.yml
+++ b/envs/rdp_classifier.yml
@@ -1,0 +1,5 @@
+name: rdp_classifier
+channels:
+- bioconda
+dependencies:
+- rdp_classifier=2.14

--- a/envs/rdp_tools.yml
+++ b/envs/rdp_tools.yml
@@ -1,5 +1,0 @@
-name: RDPtools
-channels:
-- bioconda
-dependencies:
-- rdptools=2.0.3

--- a/envs/singularity/sing_envs.yml
+++ b/envs/singularity/sing_envs.yml
@@ -9,7 +9,7 @@ r_utils: docker://metagenlab/amplicons_r_utils:v.1.0
 qiimerdp: docker://metagenlab/amplicons_qiime1_rdp:v.1.0
 qiime2: docker://qiime2/core:2020.2
 decipher: docker://metagenlab/amplicons_decipher:v.1.0
-rdptools: docker://quay.io/biocontainers/rdptools:2.0.3--0
+rdp_classifier: docker://quay.io/biocontainers/rdp_classifier:2.14--hdfd78af_0
 python: docker://python:3.12.3-slim-bullseye
 picrust2: docker://quay.io/biocontainers/picrust2:2.5.2--pyhdfd78af_0
 simulatePCR: docker://metagenlab/amplicons_simulatepcr:v.1.0

--- a/envs/singularity/sing_envs.yml
+++ b/envs/singularity/sing_envs.yml
@@ -14,3 +14,4 @@ python27: docker://python:2.7
 picrust2: docker://quay.io/biocontainers/picrust2:2.5.2--pyhdfd78af_0
 simulatePCR: docker://metagenlab/amplicons_simulatepcr:v.1.0
 TreeShrink: docker://metagenlab/amplicons_treeshrink:v.1.0
+pandas: docker://quay.io/biocontainers/pandas:2.2.1

--- a/envs/singularity/sing_envs.yml
+++ b/envs/singularity/sing_envs.yml
@@ -10,7 +10,7 @@ qiimerdp: docker://metagenlab/amplicons_qiime1_rdp:v.1.0
 qiime2: docker://qiime2/core:2020.2
 decipher: docker://metagenlab/amplicons_decipher:v.1.0
 rdptools: docker://quay.io/biocontainers/rdptools:2.0.3--0
-python27: docker://python:2.7
+python: docker://python:3.12.3-slim-bullseye
 picrust2: docker://quay.io/biocontainers/picrust2:2.5.2--pyhdfd78af_0
 simulatePCR: docker://metagenlab/amplicons_simulatepcr:v.1.0
 TreeShrink: docker://metagenlab/amplicons_treeshrink:v.1.0

--- a/rules/3_tax_assignment/tax_assign.rules
+++ b/rules/3_tax_assignment/tax_assign.rules
@@ -84,7 +84,7 @@ rule rdp_classify:
         mem_mb=30000,
     shell:
         """
-        classifier -Xmx30g -XX:ConcGCThreads=1 classify \
+        rdp_classifier -Xmx30g -XX:ConcGCThreads=1 classify \
         -c 0.5 \
         -f allrank \
         -t {input[0]} \

--- a/rules/3_tax_assignment/tax_assign.rules
+++ b/rules/3_tax_assignment/tax_assign.rules
@@ -69,9 +69,9 @@ rule dada2_assign_taxonomy_rdp:
 
 rule rdp_classify:
     conda:
-        "../../envs/rdp_tools.yml"
+        "../../envs/rdp_classifier.yml"
     container:
-        singularity_envs["rdptools"]
+        singularity_envs["rdp_classifier"]
     input:
         trained_ref=config["tax_DB_path"] + "{tax_DB}/RDP/rRNAClassifier.properties",
         query_seqs="{denoiser}/2_denoised/dna-sequences.fasta",

--- a/rules/DB_processing/DB_preprocessing.rules
+++ b/rules/DB_processing/DB_preprocessing.rules
@@ -48,28 +48,6 @@ rule Dereplicate_amplicons:
         """
 
 
-# rule Derep_and_merge_taxonomy:
-#     conda:
-#         "../../envs/amplicons_r_utils.yml"
-#     container:
-#         singularity_envs["r_utils"]
-#     input:
-#         tax="{prefix}/master/original_tax.txt",
-#         uc="{prefix}/QIIME/DB_amp.uc",
-#     output:
-#         formatted_tax="{prefix}/QIIME/DB_amp_taxonomy.txt",
-#         all="{prefix}/QIIME/DB_amp_all_taxonomy.txt",
-#         problematic="{prefix}/QIIME/problematic_taxa.txt",
-#     log:
-#         "{prefix}/logs/QIIME/derep_and_merge.log",
-#     params:
-#         numbers_species=config["numbers_species"],
-#         numbers_genus=config["numbers_genus"],
-#     threads: 1
-#     script:
-#         "scripts/DB_tax_formatting.R"
-
-
 rule Derep_and_merge_taxonomy:
     conda:
         "../../envs/pandas.yml"
@@ -85,7 +63,7 @@ rule Derep_and_merge_taxonomy:
     log:
         "{prefix}/logs/QIIME/derep_and_merge.log",
     params:
-        db_version = config["db_version"],
+        db_version=config["db_version"],
         tax_collapse=config["tax_collapse"],
     threads: 1
     script:

--- a/rules/DB_processing/DB_preprocessing.rules
+++ b/rules/DB_processing/DB_preprocessing.rules
@@ -85,6 +85,7 @@ rule Derep_and_merge_taxonomy:
     log:
         "{prefix}/logs/QIIME/derep_and_merge.log",
     params:
+        db_version = config["db_version"],
         tax_collapse=config["tax_collapse"],
     threads: 1
     script:

--- a/rules/DB_processing/DB_preprocessing.rules
+++ b/rules/DB_processing/DB_preprocessing.rules
@@ -69,6 +69,7 @@ rule Dereplicate_amplicons:
 #     script:
 #         "scripts/DB_tax_formatting.R"
 
+
 rule Derep_and_merge_taxonomy:
     conda:
         "../../envs/pandas.yml"
@@ -84,8 +85,7 @@ rule Derep_and_merge_taxonomy:
     log:
         "{prefix}/logs/QIIME/derep_and_merge.log",
     params:
-        numbers_species=config["numbers_species"],
-        numbers_genus=config["numbers_genus"],
+        tax_collapse=config["tax_collapse"],
     threads: 1
     script:
         "scripts/tax_formatting.py"

--- a/rules/DB_processing/DB_preprocessing.rules
+++ b/rules/DB_processing/DB_preprocessing.rules
@@ -63,7 +63,7 @@ rule Derep_and_merge_taxonomy:
     log:
         "{prefix}/logs/QIIME/derep_and_merge.log",
     params:
-        db_version=config["db_version"],
+        db_name=config["tax_DB_name"],
         tax_collapse=config["tax_collapse"],
     threads: 1
     script:

--- a/rules/DB_processing/DB_preprocessing.rules
+++ b/rules/DB_processing/DB_preprocessing.rules
@@ -48,11 +48,32 @@ rule Dereplicate_amplicons:
         """
 
 
+# rule Derep_and_merge_taxonomy:
+#     conda:
+#         "../../envs/amplicons_r_utils.yml"
+#     container:
+#         singularity_envs["r_utils"]
+#     input:
+#         tax="{prefix}/master/original_tax.txt",
+#         uc="{prefix}/QIIME/DB_amp.uc",
+#     output:
+#         formatted_tax="{prefix}/QIIME/DB_amp_taxonomy.txt",
+#         all="{prefix}/QIIME/DB_amp_all_taxonomy.txt",
+#         problematic="{prefix}/QIIME/problematic_taxa.txt",
+#     log:
+#         "{prefix}/logs/QIIME/derep_and_merge.log",
+#     params:
+#         numbers_species=config["numbers_species"],
+#         numbers_genus=config["numbers_genus"],
+#     threads: 1
+#     script:
+#         "scripts/DB_tax_formatting.R"
+
 rule Derep_and_merge_taxonomy:
     conda:
-        "../../envs/amplicons_r_utils.yml"
+        "../../envs/pandas.yml"
     container:
-        singularity_envs["r_utils"]
+        singularity_envs["pandas"]
     input:
         tax="{prefix}/master/original_tax.txt",
         uc="{prefix}/QIIME/DB_amp.uc",
@@ -67,7 +88,7 @@ rule Derep_and_merge_taxonomy:
         numbers_genus=config["numbers_genus"],
     threads: 1
     script:
-        "scripts/DB_tax_formatting.R"
+        "scripts/tax_formatting.py"
 
 
 rule Hash_derep_tax:

--- a/rules/DB_processing/DB_skip_preprocessing.rules
+++ b/rules/DB_processing/DB_skip_preprocessing.rules
@@ -3,19 +3,31 @@
 # set of rules will be used to bypass the preprocessing of the database.
 
 
-rule copy_untreated_DB:
+rule copy_fasta:
     input:
-        tax="{prefix}/master/original_tax.txt",
-        fasta="{prefix}/master/original_seqs.fasta",
+        "{prefix}/master/original_seqs.fasta",
     output:
-        tax="{prefix}/QIIME/DB_amp_taxonomy.txt",
-        fasta="{prefix}/QIIME/DB_amp.fasta",
-    threads: 1
+        "{prefix}/QIIME/DB_amp.fasta",
     shell:
         """
-        cp {input.tax} {output.tax} && \
-        cp {input.fasta} {output.fasta}
+        cp {input} {output}
         """
+
+
+rule clean_unprocessed_DB_taxonomy:
+    conda:
+        "../../envs/pandas.yml"
+    container:
+        singularity_envs["pandas"]
+    input:
+        tax="{prefix}/master/original_tax.txt",
+    output:
+        tax="{prefix}/QIIME/DB_amp_taxonomy.txt",
+    params:
+        db_version=config["db_version"],
+    threads: 1
+    script:
+        "scripts/clean_tax.py"
 
 
 rule Hash_untreated_tax:

--- a/rules/DB_processing/DB_skip_preprocessing.rules
+++ b/rules/DB_processing/DB_skip_preprocessing.rules
@@ -24,7 +24,7 @@ rule clean_unprocessed_DB_taxonomy:
     output:
         tax="{prefix}/QIIME/DB_amp_taxonomy.txt",
     params:
-        db_version=config["db_version"],
+        db_name=config["tax_DB_name"],
     threads: 1
     script:
         "scripts/clean_tax.py"

--- a/rules/DB_processing/RDP_validation.rules
+++ b/rules/DB_processing/RDP_validation.rules
@@ -5,9 +5,9 @@
 ### C) plot inta taxon similarity
 rule Visualize_similarity_rdp:  ## Generate a plot for intra taxa similarity. Very long to compute 
     conda:
-        "../../envs/rdp_tools.yml"
+        "../../envs/rdp_classifier.yml"
     container:
-        singularity_envs["rdptools"]
+        singularity_envs["rdp_classifier"]
     input:
         tax="{prefix}/RDP/ready4train_lineages.txt",
         seqs="{prefix}/RDP/ready4train_seqs.fasta",
@@ -35,9 +35,9 @@ rule Visualize_similarity_rdp:  ## Generate a plot for intra taxa similarity. Ve
 ### D.1) Leave one sequence out test for accuracy testing
 rule Accuracy_seqs_testing_rdp:
     conda:
-        "../../envs/rdp_tools.yml"
+        "../../envs/rdp_classifier.yml"
     container:
-        singularity_envs["rdptools"]
+        singularity_envs["rdp_classifier"]
     input:
         tax="{prefix}/RDP/ready4train_lineages.txt",
         seqs="{prefix}/RDP/ready4train_seqs.fasta",
@@ -62,9 +62,9 @@ rule Accuracy_seqs_testing_rdp:
 ### D.2) Leave one taxon out test for accuracy testing
 rule Accuracy_taxon_testing_rdp:
     conda:
-        "../../envs/rdp_tools.yml"
+        "../../envs/rdp_classifier.yml"
     container:
-        singularity_envs["rdptools"]
+        singularity_envs["rdp_classifier"]
     input:
         tax="{prefix}/RDP/ready4train_lineages.txt",
         seqs="{prefix}/RDP/ready4train_seqs.fasta",
@@ -89,9 +89,9 @@ rule Accuracy_taxon_testing_rdp:
 ### E) Cross-validate
 rule Cross_validate__rdp:
     conda:
-        "../../envs/rdp_tools.yml"
+        "../../envs/rdp_classifier.yml"
     container:
-        singularity_envs["rdptools"]
+        singularity_envs["rdp_classifier"]
     input:
         tax="{prefix}/RDP/ready4train_lineages.txt",
         seqs="{prefix}/RDP/ready4train_seqs.fasta",

--- a/rules/DB_processing/RDP_validation.rules
+++ b/rules/DB_processing/RDP_validation.rules
@@ -50,7 +50,7 @@ rule Accuracy_seqs_testing_rdp:
         mem_mb=30000,
     shell:
         """
-        classifier -Xmx30g loot \
+        rdp_classifier -Xmx30g loot \
         -q {input.seqs} \
         -s {input.seqs} \
         -t {input.tax} \
@@ -77,7 +77,7 @@ rule Accuracy_taxon_testing_rdp:
         mem_mb=30000,
     shell:
         """
-        classifier -Xmx30g loot -h \
+        rdp_classifier -Xmx30g loot -h \
         -q {input.seqs} \
         -s {input.seqs} \
         -t {input.tax} \
@@ -104,7 +104,7 @@ rule Cross_validate__rdp:
         mem_mb=30000,
     shell:
         """
-        classifier -Xmx30g crossvalidate \
+        rdp_classifier -Xmx30g crossvalidate \
         -s {input.seqs} \
         -t {input.tax} \
         -l 400 \

--- a/rules/DB_processing/format_n_train_classifiers.rules
+++ b/rules/DB_processing/format_n_train_classifiers.rules
@@ -68,7 +68,7 @@ rule Format_rdp_lineages:
     threads: 1
     shell:
         """
-        python2.7 {input.script} {input.table} > {output[0]}
+        python {input.script} {input.table} > {output[0]}
         """
 
 
@@ -86,7 +86,7 @@ rule Format_rdp_add_lineages:
     threads: 1
     shell:
         """
-        python2.7 {input.script} {input.taxonomy} {input.fasta} > {output}       
+        python {input.script} {input.taxonomy} {input.fasta} > {output}       
         """
 
 

--- a/rules/DB_processing/format_n_train_classifiers.rules
+++ b/rules/DB_processing/format_n_train_classifiers.rules
@@ -57,9 +57,9 @@ rule Preformat_for_cannonical_rdp:
 
 rule Format_rdp_lineages:
     conda:
-        "../../envs/Python2.yml"
+        "../../envs/python.yml"
     container:
-        singularity_envs["python27"]
+        singularity_envs["python"]
     input:
         table="{prefix}/RDP/formatted_tax_table.tsv",
         script=workflow.basedir + "/rules/DB_processing/scripts/lineage2taxTrain.py",
@@ -74,9 +74,9 @@ rule Format_rdp_lineages:
 
 rule Format_rdp_add_lineages:
     conda:
-        "../../envs/Python2.yml"
+        "../../envs/python.yml"
     container:
-        singularity_envs["python27"]
+        singularity_envs["python"]
     input:
         taxonomy="{prefix}/RDP/formatted_tax_table.tsv",
         fasta="{prefix}/QIIME/DB_amp.fasta",

--- a/rules/DB_processing/format_n_train_classifiers.rules
+++ b/rules/DB_processing/format_n_train_classifiers.rules
@@ -92,9 +92,9 @@ rule Format_rdp_add_lineages:
 
 rule Train_rdp_classifier:
     conda:
-        "../../envs/rdp_tools.yml"
+        "../../envs/rdp_classifier.yml"
     container:
-        singularity_envs["rdptools"]
+        singularity_envs["rdp_classifier"]
     input:
         read4train_fasta="{prefix}/RDP/ready4train_seqs.fasta",
         read4train_tax="{prefix}/RDP/ready4train_lineages.txt",

--- a/rules/DB_processing/format_n_train_classifiers.rules
+++ b/rules/DB_processing/format_n_train_classifiers.rules
@@ -114,7 +114,7 @@ rule Train_rdp_classifier:
         probabilityList=genus_wordConditionalProbList.txt
         probabilityIndex=wordConditionalProbIndexArr.txt
         wordPrior=logWordPrior.txt
-        classifierVersion=RDP Naive Bayesian rRNA Classifier Version 2.5, May 2012" > {output[1]}
+        classifierVersion=RDP Naive Bayesian rRNA Classifier Version 2.14, August 2023" > {output[1]}
         """
 
 

--- a/rules/DB_processing/format_n_train_classifiers.rules
+++ b/rules/DB_processing/format_n_train_classifiers.rules
@@ -35,7 +35,7 @@ rule Hash_DADA2:
 ## Rules to format taxonomy to fit the requirements of the original RDP.
 ### Inspired from https://john-quensen.com/tutorials/training-the-rdp-classifier/ and
 ### following RDP authors' recommendations from https://github.com/rdpstaff/classifier/tree/17bf0bd10581f05c268e963e8c4150084d172d7d
-### See 'RDP_validations.rules' for more validatino based on RDP authors' recommendations
+### See 'RDP_validations.rules' for more validation based on RDP authors' recommendations
 
 
 rule Preformat_for_cannonical_rdp:

--- a/rules/DB_processing/format_n_train_classifiers.rules
+++ b/rules/DB_processing/format_n_train_classifiers.rules
@@ -90,6 +90,13 @@ rule Format_rdp_add_lineages:
         """
 
 
+from humanfriendly import parse_size
+
+
+def get_mem_mb(mem):
+    return int(parse_size(mem) / 10**6)
+
+
 rule Train_rdp_classifier:
     conda:
         "../../envs/rdp_classifier.yml"
@@ -101,12 +108,14 @@ rule Train_rdp_classifier:
     output:
         formatted_table="{prefix}/RDP/bergeyTrainingTree.xml",
         properties="{prefix}/RDP/rRNAClassifier.properties",
+    params:
+        mem=config["rdp_mem"],
     threads: 1
     resources:
-        mem_mb=30000,
+        mem_mb=get_mem_mb(config["rdp_mem"]),
     shell:
         """
-        rdp_classifier -Xmx30g -XX:ConcGCThreads=1 train \
+        rdp_classifier -Xmx{params.mem} -XX:ConcGCThreads={threads} train \
         -o $(dirname {output[0]}) \
         -s {input[0]} \
         -t {input[1]} && \

--- a/rules/DB_processing/format_n_train_classifiers.rules
+++ b/rules/DB_processing/format_n_train_classifiers.rules
@@ -106,7 +106,7 @@ rule Train_rdp_classifier:
         mem_mb=30000,
     shell:
         """
-        classifier -Xmx30g -XX:ConcGCThreads=1 train \
+        rdp_classifier -Xmx30g -XX:ConcGCThreads=1 train \
         -o $(dirname {output[0]}) \
         -s {input[0]} \
         -t {input[1]} && \

--- a/rules/DB_processing/scripts/DB_tax_formatting.R
+++ b/rules/DB_processing/scripts/DB_tax_formatting.R
@@ -1,7 +1,7 @@
 ## Redirect R output
-log <- file(snakemake@log[[1]], open="wt")
+log <- file(snakemake@log[[1]], open = "wt")
 sink(log)
-sink(log, type="message")
+sink(log, type = "message")
 
 ## Input
 DB_tax_path <- snakemake@input[["tax"]]
@@ -18,181 +18,192 @@ n_species <- snakemake@params[["numbers_species"]]
 n_genus <- snakemake@params[["numbers_genus"]]
 
 ## Load needed libraries
-library(tidyr);packageVersion("tidyr")
-library(dplyr);packageVersion("dplyr")
-library(lattice);packageVersion("lattice")
-library(stringr);packageVersion("stringr")
-library(forcats);packageVersion("forcats")
+library(tidyr)
+packageVersion("tidyr")
+library(dplyr)
+packageVersion("dplyr")
+library(lattice)
+packageVersion("lattice")
+library(stringr)
+packageVersion("stringr")
+library(forcats)
+packageVersion("forcats")
 
 
 ## Import data
-  ### Taxonomy
-  DB_tax <- read.delim(DB_tax_path, header=FALSE, colClasses = "character", as.is = TRUE, strip.white = TRUE)
-  ## Dereplication table
-  uc_table <- read.delim(DB_uc_path, header = FALSE, as.is = TRUE, colClasses = "character", strip.white = TRUE)
+### Taxonomy
+DB_tax <- read.delim(DB_tax_path, header = FALSE, colClasses = "character", as.is = TRUE, strip.white = TRUE)
+## Dereplication table
+uc_table <- read.delim(DB_uc_path, header = FALSE, as.is = TRUE, colClasses = "character", strip.white = TRUE)
 
 
 
 ## Pre-process taxonomy
-  ### Format in case Silva database
-  DB_tax$V2 <- str_remove_all(DB_tax$V2, pattern = "'")
-  DB_tax$V2 <- str_remove_all(DB_tax$V2, pattern = "D_\\d{1,2}__")
+### Format in case Silva database
+DB_tax$V2 <- str_remove_all(DB_tax$V2, pattern = "'")
+DB_tax$V2 <- str_remove_all(DB_tax$V2, pattern = "D_\\d{1,2}__")
 
-  ### Split taxonomy based on presence of ";"
-  tax_split <- strsplit(DB_tax[,2],split = ";")
+### Split taxonomy based on presence of ";"
+tax_split <- strsplit(DB_tax[, 2], split = ";")
 
-  ### Fill in a dataframe with one column per tax level
-  tax_table <- t(sapply(tax_split,function(x){x}))
-  colnames(tax_table) <- c("Kingdom","Phylum","Class","Order","Family","Genus","Species")
-  ## Rename the row with the seq ids
-  tax_table <- data.frame(tax_table)
-  tax_table$id <- DB_tax[,1]
+### Fill in a dataframe with one column per tax level
+tax_table <- t(sapply(tax_split, function(x) {
+  x
+}))
+colnames(tax_table) <- c("Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species")
+## Rename the row with the seq ids
+tax_table <- data.frame(tax_table)
+tax_table$id <- DB_tax[, 1]
 
 
 
 ## Pre-process dereplication table
-  ### Keep clusters, i.e. deredeplicated representative sequences
-  C_uc_table <- uc_table[uc_table[,1]=="C",]
-  ### Keep replicated sequeces, i.e. sequences corresponding to a given cluster
-  H_uc_table <- uc_table[uc_table[,1]=="H",]
-  ### Bind all sequences to have all ids
-  HC_uc_table <- rbind(C_uc_table,H_uc_table)
-  ### Format this table
-  HC_uc_table <- data.frame(HC_uc_table)
-  HC_uc_table <- HC_uc_table %>%
-    rename(
-      "clust_id" = V2,
-      "seq_id" = V9,
-      "clust_rep" = V10
-      )
-  ### Keep only usefull columns
-  HC_uc_table_selec <- select(HC_uc_table, c("clust_id", "seq_id", "clust_rep"))
-  ### Set set cluster rep. sequence as its own id (instead of *)
-  HC_uc_table_selec$clust_rep[HC_uc_table_selec$clust_rep== "*"] <- HC_uc_table_selec$seq_id[HC_uc_table_selec$clust_rep== "*"]
+### Keep clusters, i.e. deredeplicated representative sequences
+C_uc_table <- uc_table[uc_table[, 1] == "C", ]
+### Keep replicated sequeces, i.e. sequences corresponding to a given cluster
+H_uc_table <- uc_table[uc_table[, 1] == "H", ]
+### Bind all sequences to have all ids
+HC_uc_table <- rbind(C_uc_table, H_uc_table)
+### Format this table
+HC_uc_table <- data.frame(HC_uc_table)
+HC_uc_table <- HC_uc_table %>%
+  rename(
+    "clust_id" = V2,
+    "seq_id" = V9,
+    "clust_rep" = V10
+  )
+### Keep only usefull columns
+HC_uc_table_selec <- select(HC_uc_table, c("clust_id", "seq_id", "clust_rep"))
+### Set set cluster rep. sequence as its own id (instead of *)
+HC_uc_table_selec$clust_rep[HC_uc_table_selec$clust_rep == "*"] <- HC_uc_table_selec$seq_id[HC_uc_table_selec$clust_rep == "*"]
 
 
 ## Merge taxonomy to clusters and format
-  merged_tax_uc <- left_join(HC_uc_table_selec, tax_table, by = c("seq_id"="id"))
-  ### Put singletons aside (they don't need to be formatted)
-  single_tax <- merged_tax_uc %>% group_by(clust_id) %>% filter(n_distinct(seq_id)==1) %>% ungroup()
-  multiple_tax <- merged_tax_uc %>% group_by(clust_id) %>% filter(n_distinct(seq_id)>1) %>% ungroup()
+merged_tax_uc <- left_join(HC_uc_table_selec, tax_table, by = c("seq_id" = "id"))
+### Put singletons aside (they don't need to be formatted)
+single_tax <- merged_tax_uc %>%
+  group_by(clust_id) %>%
+  filter(n_distinct(seq_id) == 1) %>%
+  ungroup()
+multiple_tax <- merged_tax_uc %>%
+  group_by(clust_id) %>%
+  filter(n_distinct(seq_id) > 1) %>%
+  ungroup()
 
-  ### Renomve redundant Genus name in Species ID, keeping only the last word of the vector
-  multiple_tax$Species <- sapply(strsplit(as.character(multiple_tax$Species), " "), tail, 1)
+### Renomve redundant Genus name in Species ID, keeping only the last word of the vector
+multiple_tax$Species <- sapply(strsplit(as.character(multiple_tax$Species), " "), tail, 1)
 
 
 ## Reformat the tax id helped by dplyr. Here we first group by clust_id and clust_rep to handle each cluster individually. Then using summarise, we aggregate the taxonomy.
-    #### From Kingdom to Family levels, we keep only single taxonomy IDs. If not single then, then we put a spaceholder indicating the discrepancy. This discrepancy is passed to all
-    #### levels below the discrepant taxonomic level.
-    ####
-    #### For Genus and species levels, we merge the tax ids if there are an acceptable number of different names (limit set by user). If there more taxonomic names than the limit,
-    #### then we use a spaceholder.
+#### From Kingdom to Family levels, we keep only single taxonomy IDs. If not single then, then we put a spaceholder indicating the discrepancy. This discrepancy is passed to all
+#### levels below the discrepant taxonomic level.
+####
+#### For Genus and species levels, we merge the tax ids if there are an acceptable number of different names (limit set by user). If there more taxonomic names than the limit,
+#### then we use a spaceholder.
 
 
 ### Formatted
 formatted_tax <- multiple_tax %>%
   group_by(clust_id, clust_rep) %>%
-  summarise(new_Kingdom =
-              case_when(# If there is more than one Kindgom, indicate it with a spaceholder
-                        n_distinct(Kingdom) > 1 ~ paste0("Disc.King_)", paste(unique(Kingdom), collapse = "/"), "(", n_distinct(Kingdom), ")"),
-                        # Else Keep only one kingdom for all sequence of the cluster
-                        TRUE ~ paste(unique(Kingdom), collapse = "/")
-                        )
-            ,
-            new_Phylum =
-              case_when(# If there is more than one Kindgom, indicate it with a spaceholder here too. Same for the Phylum
-                        n_distinct(Kingdom) > 1 ~ paste0("Disc.King_)", paste(unique(Kingdom), collapse = "/"), "(", n_distinct(Kingdom), ")"),
-                        n_distinct(Phylum) > 1 ~ paste0("Disc.Phy_)", paste(unique(Phylum), collapse = "/"), "(", n_distinct(Phylum), ")"),
-                        TRUE ~ paste(unique(Phylum), collapse = "/"),
-                        )
-            ,
-            new_Class =
-              case_when(n_distinct(Kingdom) > 1 ~ paste0("Disc.King_)", paste(unique(Kingdom), collapse = "/"), "(", n_distinct(Kingdom), ")"),
-                        n_distinct(Phylum) > 1 ~ paste0("Disc.Phy_)", paste(unique(Phylum), collapse = "/"), "(", n_distinct(Phylum), ")"),
-                        n_distinct(Class) > 1 ~ paste0("Disc.Class_)", paste(unique(Class), collapse = "/"), "(", n_distinct(Class), ")"),
-                        TRUE ~ paste(unique(Class), collapse = "/"),
-                        )
-            ,
-            new_Order =
-              case_when(n_distinct(Kingdom) > 1 ~ paste0("Disc.King_)", paste(unique(Kingdom), collapse = "/"), "(", n_distinct(Kingdom), ")"),
-                        n_distinct(Phylum) > 1 ~ paste0("Disc.Phy_)", paste(unique(Phylum), collapse = "/"), "(", n_distinct(Phylum), ")"),
-                        n_distinct(Class) > 1 ~ paste0("Disc.Class_)", paste(unique(Class), collapse = "/"), "(", n_distinct(Class), ")"),
-                        n_distinct(Order) > 1 ~ paste0("Disc.Ord_", paste(unique(Order), collapse = "/"), "(", n_distinct(Order), ")"),
-
-                        TRUE ~ paste(unique(Order), collapse = "/"),
-                        )
-            ,
-            new_Family =
-              case_when(n_distinct(Kingdom) > 1 ~ paste0("Disc.King_)", paste(unique(Kingdom), collapse = "/"), "(", n_distinct(Kingdom), ")"),
-                        n_distinct(Phylum) > 1 ~ paste0("Disc.Phy_)", paste(unique(Phylum), collapse = "/"), "(", n_distinct(Phylum), ")"),
-                        n_distinct(Class) > 1 ~ paste0("Disc.Class_)", paste(unique(Class), collapse = "/"), "(", n_distinct(Class), ")"),
-                        n_distinct(Order) > 1 ~ paste0("Disc.Ord_", paste(unique(Order), collapse = "/"), "(", n_distinct(Order), ")"),
-
-                        TRUE ~ paste(unique(Family), collapse = "/"),
-                        )
-            ,
-            new_Genus =
-              case_when(# Same as for above levels
-                        n_distinct(Kingdom) > 1 ~ paste0("Disc.King_)", paste(unique(Kingdom), collapse = "/"), "(", n_distinct(Kingdom), ")"),
-                        n_distinct(Phylum) > 1 ~ paste0("Disc.Phy_)", paste(unique(Phylum), collapse = "/"), "(", n_distinct(Phylum), ")"),
-                        n_distinct(Class) > 1 ~ paste0("Disc.Class_)", paste(unique(Class), collapse = "/"), "(", n_distinct(Class), ")"),
-                        n_distinct(Order) > 1 ~ paste0("Disc.Ord_", paste(unique(Order), collapse = "/"), "(", n_distinct(Order), ")"),
-                        n_distinct(Family) > 1 ~ paste0("Disc.Fam_", paste(unique(Family), collapse = "/"), "(", n_distinct(Family), ")"),
-
-
-                        TRUE ~ case_when(# Here we tolerate more than one Genus.
-                                         n_distinct(Genus) == 1 ~ paste0(unique(Genus), collapse = ""),
-                                         # If there are an acceptable number of, then we collapse them.
-                                         n_distinct(Genus) > 1 & n_distinct(Genus) <= n_genus ~ paste0(paste(unique(Genus), collapse = "/"), "(", n_distinct(Genus), ")"),
-                                         # Otherwise, we use a spaceholder
-                                         n_distinct(Genus) > n_genus ~ paste0(paste(unique(Family), collapse = "/"), " ", "gen.(", n_distinct(Genus),")"),
-                                         )
-              ),
-
-            new_Species =
-              case_when(n_distinct(Kingdom) > 1 ~ paste0("Disc.King_)", paste(unique(Kingdom), collapse = "/"), "(", n_distinct(Kingdom), ")"),
-                        n_distinct(Phylum) > 1 ~ paste0("Disc.Phy_)", paste(unique(Phylum), collapse = "/"), "(", n_distinct(Phylum), ")"),
-                        n_distinct(Class) > 1 ~ paste0("Disc.Class_)", paste(unique(Class), collapse = "/"), "(", n_distinct(Class), ")"),
-                        n_distinct(Order) > 1 ~ paste0("Disc.Ord_", paste(unique(Order), collapse = "/"), "(", n_distinct(Order), ")"),
-                        n_distinct(Family) > 1 ~ paste0("Disc.Fam_", paste(unique(Family), collapse = "/"), "(", n_distinct(Family), ")"),
-
-                        TRUE ~ case_when(# Same as for Genus, only that here we also indicate the Genus in Species.
-                                        n_distinct(Genus) > 1 ~ case_when(n_distinct(Species) <= n_species ~ paste0(paste(unique(Genus), unique(Species), collapse = "/"), "(", n_distinct(Species), ")"),
-                                                                           n_distinct(Species) > n_species ~ paste0(paste(unique(Genus), collapse = "/"), " ","sp.(", n_distinct(Species),")"),
-                                                                            ),
-                                         TRUE ~ case_when(n_distinct(Species) <= n_species ~ paste0(paste(unique(Genus), collapse = ""), " ", paste(unique(Species), collapse = "/"), "(", n_distinct(Species), ")"),
-                                                                                            n_distinct(Species) > n_species ~ paste0(paste(unique(Genus), collapse = "/"), " ", "sp.(", n_distinct(Species),")")
-                                                                                            )
-                                                                            )
-                ),
-
-            problematic_tax = case_when(n_distinct(Kingdom) > 1 ~ paste0("Disc.King_)", paste(unique(Kingdom), collapse = "/"), "(", n_distinct(Kingdom), ")"),
-                                        n_distinct(Phylum) > 1 ~ paste0("Disc.Phy_)", paste(unique(Phylum), collapse = "/"), "(", n_distinct(Phylum), ")"),
-                                        n_distinct(Class) > 1 ~ paste0("Disc.Class_)", paste(unique(Class), collapse = "/"), "(", n_distinct(Class), ")"),
-                                        n_distinct(Order) > 1 ~ paste0("Disc.Ord_", paste(unique(Order), collapse = "/"), "(", n_distinct(Order), ")"),
-                                        n_distinct(Family) > 1 ~ paste0("Disc.Fam_", paste(unique(Family), collapse = "/"), "(", n_distinct(Family), ")")
-                                        )
-                ) %>%
+  summarise(
+    new_Kingdom =
+      case_when( # If there is more than one Kindgom, indicate it with a spaceholder
+        n_distinct(Kingdom) > 1 ~ paste0("Disc.King_)", paste(unique(Kingdom), collapse = "/"), "(", n_distinct(Kingdom), ")"),
+        # Else Keep only one kingdom for all sequence of the cluster
+        TRUE ~ paste(unique(Kingdom), collapse = "/")
+      ),
+    new_Phylum =
+      case_when( # If there is more than one Kindgom, indicate it with a spaceholder here too. Same for the Phylum
+        n_distinct(Kingdom) > 1 ~ paste0("Disc.King_)", paste(unique(Kingdom), collapse = "/"), "(", n_distinct(Kingdom), ")"),
+        n_distinct(Phylum) > 1 ~ paste0("Disc.Phy_)", paste(unique(Phylum), collapse = "/"), "(", n_distinct(Phylum), ")"),
+        TRUE ~ paste(unique(Phylum), collapse = "/"),
+      ),
+    new_Class =
+      case_when(
+        n_distinct(Kingdom) > 1 ~ paste0("Disc.King_)", paste(unique(Kingdom), collapse = "/"), "(", n_distinct(Kingdom), ")"),
+        n_distinct(Phylum) > 1 ~ paste0("Disc.Phy_)", paste(unique(Phylum), collapse = "/"), "(", n_distinct(Phylum), ")"),
+        n_distinct(Class) > 1 ~ paste0("Disc.Class_)", paste(unique(Class), collapse = "/"), "(", n_distinct(Class), ")"),
+        TRUE ~ paste(unique(Class), collapse = "/"),
+      ),
+    new_Order =
+      case_when(
+        n_distinct(Kingdom) > 1 ~ paste0("Disc.King_)", paste(unique(Kingdom), collapse = "/"), "(", n_distinct(Kingdom), ")"),
+        n_distinct(Phylum) > 1 ~ paste0("Disc.Phy_)", paste(unique(Phylum), collapse = "/"), "(", n_distinct(Phylum), ")"),
+        n_distinct(Class) > 1 ~ paste0("Disc.Class_)", paste(unique(Class), collapse = "/"), "(", n_distinct(Class), ")"),
+        n_distinct(Order) > 1 ~ paste0("Disc.Ord_", paste(unique(Order), collapse = "/"), "(", n_distinct(Order), ")"),
+        TRUE ~ paste(unique(Order), collapse = "/"),
+      ),
+    new_Family =
+      case_when(
+        n_distinct(Kingdom) > 1 ~ paste0("Disc.King_)", paste(unique(Kingdom), collapse = "/"), "(", n_distinct(Kingdom), ")"),
+        n_distinct(Phylum) > 1 ~ paste0("Disc.Phy_)", paste(unique(Phylum), collapse = "/"), "(", n_distinct(Phylum), ")"),
+        n_distinct(Class) > 1 ~ paste0("Disc.Class_)", paste(unique(Class), collapse = "/"), "(", n_distinct(Class), ")"),
+        n_distinct(Order) > 1 ~ paste0("Disc.Ord_", paste(unique(Order), collapse = "/"), "(", n_distinct(Order), ")"),
+        TRUE ~ paste(unique(Family), collapse = "/"),
+      ),
+    new_Genus =
+      case_when( # Same as for above levels
+        n_distinct(Kingdom) > 1 ~ paste0("Disc.King_)", paste(unique(Kingdom), collapse = "/"), "(", n_distinct(Kingdom), ")"),
+        n_distinct(Phylum) > 1 ~ paste0("Disc.Phy_)", paste(unique(Phylum), collapse = "/"), "(", n_distinct(Phylum), ")"),
+        n_distinct(Class) > 1 ~ paste0("Disc.Class_)", paste(unique(Class), collapse = "/"), "(", n_distinct(Class), ")"),
+        n_distinct(Order) > 1 ~ paste0("Disc.Ord_", paste(unique(Order), collapse = "/"), "(", n_distinct(Order), ")"),
+        n_distinct(Family) > 1 ~ paste0("Disc.Fam_", paste(unique(Family), collapse = "/"), "(", n_distinct(Family), ")"),
+        TRUE ~ case_when( # Here we tolerate more than one Genus.
+          n_distinct(Genus) == 1 ~ paste0(unique(Genus), collapse = ""),
+          # If there are an acceptable number of, then we collapse them.
+          n_distinct(Genus) > 1 & n_distinct(Genus) <= n_genus ~ paste0(paste(unique(Genus), collapse = "/"), "(", n_distinct(Genus), ")"),
+          # Otherwise, we use a spaceholder
+          n_distinct(Genus) > n_genus ~ paste0(paste(unique(Family), collapse = "/"), " ", "gen.(", n_distinct(Genus), ")"),
+        )
+      ),
+    new_Species =
+      case_when(
+        n_distinct(Kingdom) > 1 ~ paste0("Disc.King_)", paste(unique(Kingdom), collapse = "/"), "(", n_distinct(Kingdom), ")"),
+        n_distinct(Phylum) > 1 ~ paste0("Disc.Phy_)", paste(unique(Phylum), collapse = "/"), "(", n_distinct(Phylum), ")"),
+        n_distinct(Class) > 1 ~ paste0("Disc.Class_)", paste(unique(Class), collapse = "/"), "(", n_distinct(Class), ")"),
+        n_distinct(Order) > 1 ~ paste0("Disc.Ord_", paste(unique(Order), collapse = "/"), "(", n_distinct(Order), ")"),
+        n_distinct(Family) > 1 ~ paste0("Disc.Fam_", paste(unique(Family), collapse = "/"), "(", n_distinct(Family), ")"),
+        TRUE ~ case_when( # Same as for Genus, only that here we also indicate the Genus in Species.
+          n_distinct(Genus) > 1 ~ case_when(
+            n_distinct(Species) <= n_species ~ paste0(paste(unique(Genus), unique(Species), collapse = "/"), "(", n_distinct(Species), ")"),
+            n_distinct(Species) > n_species ~ paste0(paste(unique(Genus), collapse = "/"), " ", "sp.(", n_distinct(Species), ")"),
+          ),
+          TRUE ~ case_when(
+            n_distinct(Species) <= n_species ~ paste0(paste(unique(Genus), collapse = ""), " ", paste(unique(Species), collapse = "/"), "(", n_distinct(Species), ")"),
+            n_distinct(Species) > n_species ~ paste0(paste(unique(Genus), collapse = "/"), " ", "sp.(", n_distinct(Species), ")")
+          )
+        )
+      ),
+    problematic_tax = case_when(
+      n_distinct(Kingdom) > 1 ~ paste0("Disc.King_)", paste(unique(Kingdom), collapse = "/"), "(", n_distinct(Kingdom), ")"),
+      n_distinct(Phylum) > 1 ~ paste0("Disc.Phy_)", paste(unique(Phylum), collapse = "/"), "(", n_distinct(Phylum), ")"),
+      n_distinct(Class) > 1 ~ paste0("Disc.Class_)", paste(unique(Class), collapse = "/"), "(", n_distinct(Class), ")"),
+      n_distinct(Order) > 1 ~ paste0("Disc.Ord_", paste(unique(Order), collapse = "/"), "(", n_distinct(Order), ")"),
+      n_distinct(Family) > 1 ~ paste0("Disc.Fam_", paste(unique(Family), collapse = "/"), "(", n_distinct(Family), ")")
+    )
+  ) %>%
   ungroup()
 
 
 ### Version without collapse
 raw_tax <- multiple_tax %>%
   group_by(clust_id, clust_rep) %>%
-  summarise(new_Kingdom = paste0(unique(Kingdom), collapse = "/"),
-            new_Phylum =  paste0(unique(Phylum), collapse = "/"),
-            new_Class = paste0(unique(Class), collapse = "/"),
-            new_Order = paste0(unique(Order), collapse = "/"),
-            new_Family = paste0(unique(Family), collapse = "/"),
-            new_Genus = paste0(unique(Genus), collapse = "/"),
-            new_Species = paste0(paste(unique(Genus), collapse = ""), " ", paste(unique(Species), collapse = "/"), "(", n_distinct(Species), ")"),
-            problematic_tax = case_when(n_distinct(Kingdom) > 1 ~ paste0("Disc.King_)", paste(unique(Kingdom), collapse = "/"), "(", n_distinct(Kingdom), ")"),
-                                        n_distinct(Phylum) > 1 ~ paste0("Disc.Phy_)", paste(unique(Phylum), collapse = "/"), "(", n_distinct(Phylum), ")"),
-                                        n_distinct(Class) > 1 ~ paste0("Disc.Class_)", paste(unique(Class), collapse = "/"), "(", n_distinct(Class), ")"),
-                                        n_distinct(Order) > 1 ~ paste0("Disc.Ord_", paste(unique(Order), collapse = "/"), "(", n_distinct(Order), ")"),
-                                        n_distinct(Family) > 1 ~ paste0("Disc.Fam_", paste(unique(Family), collapse = "/"), "(", n_distinct(Family), ")")
-            )
-            ) %>%
+  summarise(
+    new_Kingdom = paste0(unique(Kingdom), collapse = "/"),
+    new_Phylum = paste0(unique(Phylum), collapse = "/"),
+    new_Class = paste0(unique(Class), collapse = "/"),
+    new_Order = paste0(unique(Order), collapse = "/"),
+    new_Family = paste0(unique(Family), collapse = "/"),
+    new_Genus = paste0(unique(Genus), collapse = "/"),
+    new_Species = paste0(paste(unique(Genus), collapse = ""), " ", paste(unique(Species), collapse = "/"), "(", n_distinct(Species), ")"),
+    problematic_tax = case_when(
+      n_distinct(Kingdom) > 1 ~ paste0("Disc.King_)", paste(unique(Kingdom), collapse = "/"), "(", n_distinct(Kingdom), ")"),
+      n_distinct(Phylum) > 1 ~ paste0("Disc.Phy_)", paste(unique(Phylum), collapse = "/"), "(", n_distinct(Phylum), ")"),
+      n_distinct(Class) > 1 ~ paste0("Disc.Class_)", paste(unique(Class), collapse = "/"), "(", n_distinct(Class), ")"),
+      n_distinct(Order) > 1 ~ paste0("Disc.Ord_", paste(unique(Order), collapse = "/"), "(", n_distinct(Order), ")"),
+      n_distinct(Family) > 1 ~ paste0("Disc.Fam_", paste(unique(Family), collapse = "/"), "(", n_distinct(Family), ")")
+    )
+  ) %>%
   ungroup()
 
 
@@ -206,23 +217,22 @@ prob_tax <- raw_tax %>% filter(!is.na(problematic_tax))
 write.csv(x = prob_tax, file = problematic_tax_path, quote = FALSE, row.names = FALSE, sep = ";")
 
 ## Singeltons
-taxa_col <- c("Kingdom","Phylum","Class","Order","Family","Genus","Species")
+taxa_col <- c("Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species")
 single_tax_collapsed <- single_tax %>%
-  unite(remove = TRUE,  col = "taxonomy", taxa_col, sep = ";") %>%
+  unite(remove = TRUE, col = "taxonomy", taxa_col, sep = ";") %>%
   select(-c(seq_id, clust_id))
 
 ### Formatted taxonomy
-taxa_col <- c("new_Kingdom","new_Phylum","new_Class","new_Order","new_Family","new_Genus","new_Species")
+taxa_col <- c("new_Kingdom", "new_Phylum", "new_Class", "new_Order", "new_Family", "new_Genus", "new_Species")
 formatted_tax_collapsed <- formatted_tax %>%
-  unite(remove = TRUE,  col = "taxonomy", taxa_col, sep = ";") %>%
+  unite(remove = TRUE, col = "taxonomy", taxa_col, sep = ";") %>%
   select(-c(problematic_tax, clust_id))
 formatted_tax_collapsed_w_s <- rbind(single_tax_collapsed, formatted_tax_collapsed)
-write.table(x = formatted_tax_collapsed_w_s, file = formatted_tax_path ,quote = FALSE, sep="\t",row.names = FALSE ,col.names = FALSE)
+write.table(x = formatted_tax_collapsed_w_s, file = formatted_tax_path, quote = FALSE, sep = "\t", row.names = FALSE, col.names = FALSE)
 
 ### Unformatted taxonomy
 raw_tax_collapsed <- raw_tax %>%
-  unite(remove = TRUE,  col = "taxonomy", taxa_col, sep = ";") %>%
+  unite(remove = TRUE, col = "taxonomy", taxa_col, sep = ";") %>%
   select(-c(problematic_tax, clust_id))
 raw_tax_collapsed_w_s <- rbind(single_tax_collapsed, raw_tax_collapsed)
-write.table(x = raw_tax_collapsed_w_s, file = all_tax_path ,quote = FALSE, sep="\t",row.names = FALSE ,col.names = FALSE)
-
+write.table(x = raw_tax_collapsed_w_s, file = all_tax_path, quote = FALSE, sep = "\t", row.names = FALSE, col.names = FALSE)

--- a/rules/DB_processing/scripts/addFullLineage.py
+++ b/rules/DB_processing/scripts/addFullLineage.py
@@ -1,41 +1,42 @@
 ## Reproduced from https://github.com/GLBRC-TeamMicrobiome/python_scripts
 
 #!/usr/bin/python
-import sys, string
+import sys
+
 if len(sys.argv) != 3:
-	print 'addFullLineage.py taxonomyFile fastaFile'
-	sys.exit()
-f1 = open(sys.argv[1], 'r').readlines()
-hash = {} #lineage map
+    print("addFullLineage.py taxonomyFile fastaFile")
+    sys.exit()
+f1 = open(sys.argv[1], "r").readlines()
+hash = {}  # lineage map
 for line in f1[1:]:
-	line = line.strip()
-	#convert to unicode to avoid trouble from non-unicode source file
-	#line = unicode(line, "UTF-8")#strip non-unicode non-breaking space
-	#line = line.strip(u"\u00A0")
-	cols = line.strip().split('\t')
-	lineage = ['Root']
-	for node in cols[1:]:
-		node = node.strip()
-		if not (node == '-' or node == ''):
-			lineage.append(node)
-	ID = cols[0]
-	lineage = string.join(lineage, ';').strip()
-	hash[ID] = lineage
-f2 = open(sys.argv[2], 'r').readlines()
+    line = line.strip()
+    # convert to unicode to avoid trouble from non-unicode source file
+    # line = unicode(line, "UTF-8")#strip non-unicode non-breaking space
+    # line = line.strip(u"\u00A0")
+    cols = line.strip().split("\t")
+    lineage = ["Root"]
+    for node in cols[1:]:
+        node = node.strip()
+        if not (node == "-" or node == ""):
+            lineage.append(node)
+    ID = cols[0]
+    lineage = ";".join(lineage).strip()
+    hash[ID] = lineage
+f2 = open(sys.argv[2], "r").readlines()
 for line in f2:
-	line = line.strip()
-	if line == '':
-		continue
-	#convert to unicode to avoid trouble from non-unicode source file
-	#line = unicode(line, "UTF-8")#strip non-unicode non-breaking space
-	#line = line.strip(u"\u00A0")
-	if line[0] == '>':
-		ID = line.strip().split()[0].replace('>', '')
-		try:
-			lineage = hash[ID]
-		except KeyError:
-			print ID, 'not in taxonomy file'
-			sys.exit()
-		print '>' + ID + '\t' + lineage
-	else:
-			print line.strip()
+    line = line.strip()
+    if line == "":
+        continue
+    # convert to unicode to avoid trouble from non-unicode source file
+    # line = unicode(line, "UTF-8")#strip non-unicode non-breaking space
+    # line = line.strip(u"\u00A0")
+    if line[0] == ">":
+        ID = line.strip().split()[0].replace(">", "")
+        try:
+            lineage = hash[ID]
+        except KeyError:
+            print(ID, "not in taxonomy file")
+            sys.exit()
+        print(">" + ID + "\t" + lineage)
+    else:
+        print(line.strip())

--- a/rules/DB_processing/scripts/clean_tax.py
+++ b/rules/DB_processing/scripts/clean_tax.py
@@ -1,0 +1,71 @@
+import pandas as pd
+import numpy as np
+
+
+def propagate_nan(df):
+    # Identify columns that have NaN values
+    nan_mask = df.isna()
+
+    # Create a cumulative sum mask to propagate NaNs
+    nan_cumsum = nan_mask.cumsum(axis=1)
+
+    # Any value where the cumulative sum is greater than 0 should be NaN
+    df[nan_cumsum > 0] = np.nan
+
+    return df
+
+
+df = pd.read_csv(snakemake.input[0], sep="\t")
+df.columns = ["seq_id", "tax"]
+
+ranks = ["Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species"]
+
+if snakemake.params.db_version == "greengenes2":
+    df.tax = df.tax.str.replace("; ", ";")
+    ## Remove leading k__ to s__ in GTDB taxonomy
+    df.tax = df.tax.replace(to_replace=r"[a-z]__", value="", regex=True)
+
+lintax_df = df.tax.str.split(";", expand=True).loc[:, 0:6]
+lintax_df.columns = ranks
+lintax_df = lintax_df.replace("", np.nan).fillna(np.nan)
+
+
+if snakemake.params.db_version == "greengenes2":
+    # In greeengenes2, some sequences have the same taxa name assigned to multiple ranks
+    # the code below iterates over ranks and replaces duplicate names with NaN
+    # This mitigates convergent taxonomy errors in RDP
+    array = lintax_df.to_numpy()
+
+    # Iterate through the array to replace duplicates with NaN
+for i in range(array.shape[0]):
+    seen = set()
+    for j in range(array.shape[1]):
+        if array[i, j] in seen:
+            array[i, j] = np.nan
+        else:
+            seen.add(array[i, j])
+lintax_df = pd.DataFrame(array, columns=lintax_df.columns)
+
+
+filled_df = propagate_nan(lintax_df).ffill(axis=1)
+prop_tax_df = pd.DataFrame()
+for n, rank in enumerate(ranks):
+    if rank != ranks[0]:
+        prev = ranks[n - 1]
+        if rank == "Species":
+            placeholder = rank[0:2].lower()
+        else:
+            placeholder = rank[0].lower()
+        duplicated = (
+            filled_df[filled_df[f"{prev}"] == filled_df[f"{rank}"]][f"{rank}"]
+            + f"_{placeholder}"
+        )
+        prop_tax_df[f"{rank}"] = lintax_df[f"{rank}"].combine_first(duplicated)
+    else:
+        prop_tax_df[f"{rank}"] = filled_df[f"{rank}"]
+
+prop_tax_df["taxpath"] = prop_tax_df[ranks].T.agg(";".join)
+df = df.join(prop_tax_df)
+df[["seq_id", "taxpath"]].to_csv(
+    snakemake.output[0], sep="\t", index=False, header=False
+)

--- a/rules/DB_processing/scripts/clean_tax.py
+++ b/rules/DB_processing/scripts/clean_tax.py
@@ -20,11 +20,11 @@ df.columns = ["seq_id", "tax"]
 
 ranks = ["Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species"]
 
-if snakemake.params.db_version == "unite10":
+if snakemake.params.db_name == "unite10":
     df.tax = df.tax.replace(to_replace=r"[a-z]__", value="", regex=True)
     df.tax = df.tax.replace(to_replace=r"_", value=" ", regex=True)
 
-if snakemake.params.db_version == "greengenes2":
+if snakemake.params.db_name == "greengenes2":
     df.tax = df.tax.str.replace("; ", ";")
     ## Remove leading k__ to s__ in GTDB taxonomy
     df.tax = df.tax.replace(to_replace=r"[a-z]__", value="", regex=True)
@@ -34,10 +34,7 @@ lintax_df = df.tax.str.split(";", expand=True).loc[:, 0:6]
 lintax_df.columns = ranks
 lintax_df = lintax_df.replace("", np.nan).fillna(np.nan)
 
-if snakemake.params.db_version == "silva138.1":
-    ## Replace spaces with underscores (some genera names have spaces)
-    lintax_df.replace(to_replace=r" ", value="-", regex=True, inplace=True)
-
+if snakemake.params.db_name == "silva138.1":
     ## Replace taxa containing and Unkown or Incertae with NaN
     lintax_df.replace(
         to_replace=r".*Incertae.*|.*Unknown.*", value=np.nan, regex=True, inplace=True
@@ -47,7 +44,7 @@ if snakemake.params.db_version == "silva138.1":
     lintax_df.replace("endosymbionts", np.nan, inplace=True)
 
 
-if snakemake.params.db_version == "greengenes2":
+if snakemake.params.db_name == "greengenes2":
     # In greeengenes2, some sequences have the same taxa name assigned to multiple ranks
     # the code below iterates over ranks and replaces duplicate names with NaN
     # This mitigates convergent taxonomy errors in RDP
@@ -81,7 +78,7 @@ for n, rank in enumerate(ranks):
     else:
         prop_tax_df[f"{rank}"] = filled_df[f"{rank}"]
 
-if snakemake.params.db_version == "silva138.1":
+if snakemake.params.db_name == "silva138.1":
     ## Get classified species index
     index = ~prop_tax_df["Species"].str.contains("_sp")
     ## Add genus name in species for classified species

--- a/rules/DB_processing/scripts/lineage2taxTrain.py
+++ b/rules/DB_processing/scripts/lineage2taxTrain.py
@@ -2,51 +2,51 @@
 
 #!/usr/bin/env python
 
-#used to convert a taxonomy in tab-delimited file containing the taxonomic hierarchical structure to RDP Classifier taxonomy training file
-#Approach:each taxon is uniquely identified by the combination of its tax id and depth from the root rank, its attributes comprise: name, parent taxid, and level of depth from the root rank. 
-import sys, string
+# used to convert a taxonomy in tab-delimited file containing the taxonomic hierarchical structure to RDP Classifier taxonomy training file
+# Approach:each taxon is uniquely identified by the combination of its tax id and depth from the root rank, its attributes comprise: name, parent taxid, and level of depth from the root rank.
+import sys
 if not len(sys.argv) == 2:
-	print "lineage2taxTrain.py taxonomyFile"
-	sys.exit()
+    print("lineage2taxTrain.py taxonomyFile")
+    sys.exit()
 
-f = open(sys.argv[1], 'r').readlines()
+f = open(sys.argv[1], "r").readlines()
 header = f[0]
-header = f[0].strip().split('\t')[1:]#header: list of ranks
-hash = {}#taxon name-id map
-ranks = {}#column number-rank map
-lineages = []#list of unique lineages
+header = f[0].strip().split("\t")[1:]  # header: list of ranks
+hash = {}  # taxon name-id map
+ranks = {}  # column number-rank map
+lineages = set()  # list of unique lineages
 
-hash = {"Root":0}#initiate root rank taxon id map
+hash = {"Root": 0}  # initiate root rank taxon id map
 for i in range(len(header)):
-	name = header[i]
-	ranks[i] = name
-root = ['0', 'Root', '-1', '0', 'rootrank']#root rank info
-print string.join(root, '*')
-ID = 0 #taxon id
+    name = header[i]
+    ranks[i] = name
+root = ["0", "Root", "-1", "0", "rootrank"]  # root rank info
+print("*".join(root))
+ID = 0  # taxon id
 for line in f[1:]:
-	cols = line.strip().split('\t')[1:]
-	for i in range(len(cols)):#iterate each column
-		name = []
-		for node in cols[:i + 1]:
-			node = node.strip()
-			if not node in ('-', ''):
-				name.append(node)
-		pName = string.join(name[:-1], ';')
-		if not name in lineages:
-			lineages.append(name)
-		depth = len(name)
-		name = string.join(name, ';')
-		if name in hash.keys():#already seen this lineage
-			continue
-		try:
-			rank = ranks[i]
-		except KeyError:
-			print cols
-			sys.exit()
-		if i == 0:
-			pName = 'Root'
-		pID = hash[pName]#parent taxid
-		ID += 1
-		hash[name] = ID #add name-id to the map
-		out = ['%s'%ID, name.split(';')[-1], '%s'%pID, '%s'%depth, rank] 
-		print string.join(out, '*')
+    cols = line.strip().split("\t")[1:]
+    for i in range(len(cols)):  # iterate each column
+        name = []
+        for node in cols[: i + 1]:
+            node = node.strip()
+            if not node in ("-", ""):
+                name.append(node)
+        pName = ";".join(name[:-1])
+        if not name[0] in lineages:
+            lineages.add(name[0])
+        depth = len(name)
+        name = ";".join(name)
+        if name in hash.keys():  # already seen this lineage
+            continue
+        try:
+            rank = ranks[i]
+        except KeyError:
+            print(cols)
+            sys.exit()
+        if i == 0:
+            pName = "Root"
+        pID = hash[pName]  # parent taxid
+        ID += 1
+        hash[name] = ID  # add name-id to the map
+        out = ["%s" % ID, name.split(";")[-1], "%s" % pID, "%s" % depth, rank]
+        print("*".join(out))

--- a/rules/DB_processing/scripts/tax_formatting.py
+++ b/rules/DB_processing/scripts/tax_formatting.py
@@ -3,8 +3,25 @@ import numpy as np
 
 
 # Functions
+def propagate_nan(df):
+    # Identify columns that have NaN values
+    nan_mask = df.isna()
+
+    # Create a cumulative sum mask to propagate NaNs
+    nan_cumsum = nan_mask.cumsum(axis=1)
+
+    # Any value where the cumulative sum is greater than 0 should be NaN
+    df[nan_cumsum > 0] = np.nan
+
+    return df
+
+
 def dedup_set(s):
     return list(set(s))[0]
+
+
+def sorted_set(s):
+    return sorted(set(s))
 
 
 def format_discrepant_tax(rank, tax, rank_lim=None, print_desc=True):
@@ -33,10 +50,7 @@ def problematic_taxa(row):
 
 # Ranks list
 ranks = ["Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species"]
-ranks_lim = {
-    "Species": snakemake.params.numbers_species,
-    "Genus": snakemake.params.numbers_genus,
-}
+ranks_lim = snakemake.params.tax_collapse
 
 # Read tables
 tax_df = pd.read_csv(snakemake.input.tax, sep="\t", names=["seq_id", "tax"])
@@ -60,13 +74,26 @@ uc_df = pd.read_csv(
 ## Split taxonomy path into one column per rank
 lintax_df = tax_df.tax.str.split(";", expand=True).loc[:, 0:6]
 lintax_df.columns = ranks
+
 ## Replace empty values by NaN
 lintax_df = lintax_df.replace("", np.nan).fillna(np.nan)
 
-## Replace NaN values by latest no NaN value (forward fill)
-filled_df = lintax_df.ffill(axis=1)
+## Replace spaces with underscores (some genera names have spaces)
+lintax_df.replace(to_replace=r" ", value="-", regex=True, inplace=True)
 
-## Propagate latest non NaN taxon to empty ones
+## Replace taxa containing and Unkown or Incertae with NaN
+lintax_df.replace(
+    to_replace=r".*Incertae.*|.*Unknown.*", value=np.nan, regex=True, inplace=True
+)
+
+## Replace endosymbionts by NaN
+lintax_df.replace("endosymbionts", np.nan, inplace=True)
+
+
+## Propagate NaN value to downstream ranks and fill NaN with latest non NaN value
+filled_df = propagate_nan(lintax_df).ffill(axis=1)
+
+
 ## Check repeated values and append them with first letter rank suffix
 prop_tax_df = pd.DataFrame()
 for n, rank in enumerate(ranks):
@@ -79,6 +106,7 @@ for n, rank in enumerate(ranks):
         prop_tax_df[f"{rank}"] = lintax_df[f"{rank}"].combine_first(duplicated)
     else:
         prop_tax_df[f"{rank}"] = filled_df[f"{rank}"]
+
 
 ## Get classified species index
 index = ~prop_tax_df["Species"].str.contains("_s")
@@ -130,7 +158,7 @@ multi_df = clust_df[clust_df.seq_counts > 1]
 
 # Deal with discrepant clusters (contain multiple taxonomies)
 ## List unique taxa by cluster for all ranks
-multi_df = multi_df.groupby("clust_id", as_index=False)[ranks].aggregate(set)
+multi_df = multi_df.groupby("clust_id", as_index=False)[ranks].aggregate(sorted_set)
 
 
 # Flag clusters with multiple taxa as descrepent for all ranks

--- a/rules/DB_processing/scripts/tax_formatting.py
+++ b/rules/DB_processing/scripts/tax_formatting.py
@@ -23,7 +23,7 @@ def sorted_set(s):
     return sorted(set(s))
 
 
-def format_discrepant_tax(rank, tax, rank_lim=None, print_desc=True):
+def format_discrepant_tax(rank, tax, rank_lim=None):
     total_nb = len(tax)
     if rank_lim:
         try:
@@ -31,11 +31,12 @@ def format_discrepant_tax(rank, tax, rank_lim=None, print_desc=True):
             tax = list(tax)[0:nb_print]
         except KeyError:
             tax = list(tax)
-
-    if total_nb > 1:
-        return  "/".join(tax) + f"({total_nb})"
+        if total_nb > 1:
+            return  "/".join(tax) + f" ({total_nb})"
+        else:
+            return list(tax)[0]  
     else:
-        return list(tax)[0]
+        return "/".join(tax)
 
 
 def problematic_taxa(row):
@@ -206,7 +207,7 @@ for rank in ranks:
         lambda x: format_discrepant_tax(rank, x, ranks_lim)
     )
     multi_df.loc[:, f"all_{rank}"] = multi_df.loc[:, f"{rank}"].apply(
-        lambda x: format_discrepant_tax(rank, x, print_desc=False)
+        lambda x: format_discrepant_tax(rank, x)
     )
 
 

--- a/rules/DB_processing/scripts/tax_formatting.py
+++ b/rules/DB_processing/scripts/tax_formatting.py
@@ -70,7 +70,9 @@ ranks = ["Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species"]
 ranks_lim = snakemake.params.tax_collapse
 
 # Read tables
-tax_df = pd.read_csv(snakemake.input.tax, sep="\t", names=["seq_id", "tax"])
+tax_df = pd.read_csv(snakemake.input.tax, sep="\t")
+tax_df.columns = ["seq_id", "tax"]
+
 uc_df = pd.read_csv(
     snakemake.input.uc,
     sep="\t",

--- a/rules/DB_processing/scripts/tax_formatting.py
+++ b/rules/DB_processing/scripts/tax_formatting.py
@@ -1,0 +1,193 @@
+import pandas as pd
+import numpy as np
+
+
+# Functions
+def dedup_set(s):
+    return list(set(s))[0]
+
+
+def format_discrepant_tax(rank, tax, rank_lim=None, print_desc=True):
+    total_nb = len(tax)
+    if rank_lim:
+        try:
+            nb_print = rank_lim[f"{rank}"]
+            tax = list(tax)[0:nb_print]
+        except KeyError:
+            tax = list(tax)
+
+    if total_nb > 1:
+        if print_desc:
+            prefix = f"Disc.{rank}_"
+        else:
+            prefix = ""
+
+        return prefix + "/".join(tax) + f"({total_nb})"
+    else:
+        return list(tax)[0]
+
+
+def problematic_taxa(row):
+    return any("/" in str(cell) for cell in row)
+
+
+# Ranks list
+ranks = ["Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species"]
+ranks_lim = {
+    "Species": snakemake.params.numbers_species,
+    "Genus": snakemake.params.numbers_genus,
+}
+
+# Read tables
+tax_df = pd.read_csv(snakemake.input.tax, sep="\t", names=["seq_id", "tax"])
+uc_df = pd.read_csv(
+    snakemake.input.uc,
+    sep="\t",
+    names=[
+        "record_type",
+        "cluster_id",
+        "seq_length",
+        "percent_identity",
+        "strand",
+        "not_used1",
+        "not_used2",
+        "comp_align",
+        "query_id",
+        "target_id",
+    ],
+)
+# Taxonomy table
+## Split taxonomy path into one column per rank
+lintax_df = tax_df.tax.str.split(";", expand=True).loc[:, 0:6]
+lintax_df.columns = ranks
+## Replace empty values by NaN
+lintax_df = lintax_df.replace("", np.nan).fillna(np.nan)
+
+## Replace NaN values by latest no NaN value (forward fill)
+filled_df = lintax_df.ffill(axis=1)
+
+## Propagate latest non NaN taxon to empty ones
+## Check repeated values and append them with first letter rank suffix
+prop_tax_df = pd.DataFrame()
+for n, rank in enumerate(ranks):
+    if rank != "kingdom":
+        prev = ranks[n - 1]
+        duplicated = (
+            filled_df[filled_df[f"{prev}"] == filled_df[f"{rank}"]][f"{rank}"]
+            + f"_{rank[0].lower()}"
+        )
+        prop_tax_df[f"{rank}"] = lintax_df[f"{rank}"].combine_first(duplicated)
+    else:
+        prop_tax_df[f"{rank}"] = filled_df[f"{rank}"]
+
+## Get classified species index
+index = ~prop_tax_df["Species"].str.contains("_s")
+## Add genus name in species for classified species
+prop_tax_df.loc[index, "Species"] = (
+    prop_tax_df.loc[index, "Genus"] + " " + prop_tax_df.loc[index, "Species"]
+)
+
+
+## Add seq_id to formatted taxonomy
+tax_df = prop_tax_df.join(tax_df)
+
+# Vsearch output table
+## Extract C and H hits, check https://www.drive5.com/usearch/manual6/ucout.html for more info
+clust_df = uc_df[uc_df.record_type.isin(["C", "H"])][
+    ["record_type", "cluster_id", "query_id", "target_id"]
+]
+
+## Rename columns
+clust_df.columns = ["record_type", "clust_id", "seq_id", "clust_rep"]
+## Replace * with seqid
+clust_df.loc[clust_df["clust_rep"] == "*", "clust_rep"] = clust_df["seq_id"]
+
+## Add taxonomy to clusters
+clust_df = clust_df.merge(tax_df, on="seq_id")
+
+## Get unique taxonomy indexes
+ranks_idxs = (
+    clust_df.groupby(ranks)["clust_id"].transform(lambda x: pd.factorize(x)[0]) + 1
+)
+clust_df.insert(clust_df.shape[1], "rank_idx", ranks_idxs)
+
+
+## For unclassified taxa, add index in taxon name for each cluster
+### Example : Two Pseudoclavibacter_s sequences clusterin into clusters
+###           will be named Pseudoclavibacter_s1 and Pseudoclavibacter_s2 for each cluster
+for rank in ranks:
+    clust_df.loc[clust_df[f"{rank}"].str.contains("_"), f"{rank}"] = clust_df.loc[
+        clust_df[f"{rank}"].str.contains("_"), f"{rank}"
+    ] + clust_df.loc[clust_df[f"{rank}"].str.contains("_"), "rank_idx"].astype(str)
+
+## Count sequences in each cluster
+clust_df["seq_counts"] = clust_df.groupby("clust_id")["seq_id"].transform("count")
+
+# Split table into single and multiple hits
+single_df = clust_df[clust_df.seq_counts == 1]
+multi_df = clust_df[clust_df.seq_counts > 1]
+
+
+# Deal with discrepant clusters (contain multiple taxonomies)
+## List unique taxa by cluster for all ranks
+multi_df = multi_df.groupby("clust_id", as_index=False)[ranks].aggregate(set)
+
+
+# Flag clusters with multiple taxa as descrepent for all ranks
+## print only 2 species and 4 genus (by default) in formatted_rank
+## print all ranks in raw_rank
+for rank in ranks:
+    multi_df.loc[:, f"formatted_{rank}"] = multi_df.loc[:, f"{rank}"].apply(
+        lambda x: format_discrepant_tax(rank, x, ranks_lim)
+    )
+    multi_df.loc[:, f"all_{rank}"] = multi_df.loc[:, f"{rank}"].apply(
+        lambda x: format_discrepant_tax(rank, x, print_desc=False)
+    )
+
+
+## Add seq_id, clust_id, clust_rep and seq_counts to dataframe
+multi_df = multi_df.merge(
+    clust_df[["clust_id", "seq_id", "clust_rep", "seq_counts"]], on="clust_id"
+)
+
+## Columns in raw table
+cols = ["clust_id", "clust_rep", "seq_id"] + ranks + ["seq_counts"]
+
+
+# Df with collapsed taxonomy
+
+formatted_ranks = [f"formatted_{rank}" for rank in ranks]
+multi_formatted_df = multi_df[
+    ["clust_id", "clust_rep", "seq_id"] + formatted_ranks + ["seq_counts"]
+]
+multi_formatted_df.columns = cols
+collapsed_df = pd.concat([single_df[cols], multi_formatted_df])
+collapsed_df["taxpath"] = collapsed_df[ranks].T.agg(";".join)
+
+# Df with uncollapsed taxonomy
+
+all_ranks = [f"all_{rank}" for rank in ranks]
+multi_all_df = multi_df[
+    ["clust_id", "clust_rep", "seq_id"] + all_ranks + ["seq_counts"]
+]
+multi_all_df.columns = cols
+all_df = pd.concat([single_df[cols], multi_all_df])
+all_df["taxpath"] = all_df[ranks].T.agg(";".join)
+
+## Flag discrepant taxa as problematic
+all_df.loc[:, "problematic_taxa"] = all_df.apply(problematic_taxa, axis=1)
+
+
+# Save tables
+
+all_df[all_df.problematic_taxa == True].to_csv(
+    snakemake.output.problematic, sep="\t", index=False
+)
+
+collapsed_df[["seq_id", "taxpath"]].to_csv(
+    snakemake.output.formatted_tax, sep="\t", index=False, header=False
+)
+
+all_df[["seq_id", "taxpath"]].to_csv(
+    snakemake.output.all, sep="\t", index=False, header=False
+)

--- a/rules/DB_processing/trace_n_log_DB.rules
+++ b/rules/DB_processing/trace_n_log_DB.rules
@@ -30,17 +30,26 @@ rule Hash_master_files:
 
 
 ## Generate a hash from all relevant files to insure that we always work with the same reference databases
+
+hashes = {
+    "RDP": "{prefix}/RDP/RDP_DB.hash",
+    "qiimerdp": "{prefix}/QIIME/DB_formatted.hash",
+    "dada2rdp": "{prefix}/dada2rdp/DADA2_DB.hash",
+    "decipher": "{prefix}/RDP/RDP_DB.hash",
+}
+
+hash_out = ["{prefix}/master/original.hash"]
+for classifier in config["classifier"]:
+    hash_out.append(hashes[classifier])
+
+
 rule hash_global_DB:
     input:
-        master="{prefix}/master/original.hash",
-        QIIME="{prefix}/QIIME/DB_formatted.hash",
-        DADA2="{prefix}/dada2rdp/DADA2_DB.hash",
-        RDP="{prefix}/RDP/RDP_DB.hash",
-        decipher="{prefix}/decipher/decipher_DB.hash",
+        hash_out,
     output:
-        trained_tax="{prefix}/DB.hash",
+        "{prefix}/DB.hash",
     threads: 1
     shell:
         """
-        md5sum {input.master} {input.QIIME} {input.DADA2} {input.RDP} {input.decipher} | sort -k 2 | md5sum | cut -f 1 -d " " > {output}
+        md5sum {input} | sort -k 2 | md5sum | cut -f 1 -d " " > {output}
         """


### PR DESCRIPTION
PR for version 0.9.20

# Summary

* Updated pre-processing for [Silva 138.1 (with species)](https://zenodo.org/records/4587955)
* Updated pre-processing for [Greengenes2](http://ftp.microbio.me/greengenes_release/current/)
* Updated rdp_classifier version from 2.5 to 2.14 
* Optimized lineage2taxTrain.py
* Added taxa formatting when no pre-processing for Silva 138.1, Greengenes2, ezBiocloud and UNITE
    * Solved convergent taxa in Silva 138.1 and Greengenes2


# Details

## `Additions`

* 5627a03e705a4b94b92ed98f8e8152d43a5348e8 Added conda env and container for pandas
* d1d38607f51692200602eb55aae455c63ba36232  Added python script for derep_and_merge_taxonomy: 
    * Fills empty taxa with placeholder names (ex: Escherichia-shigella_s)
    * Replaces Incertae, unkown and endosymbionts with NaN (caused convergent taxons for rdp)
    * For unclassified taxa, each taxa corresponding to a different cluster will have a unique index
* cc8540a Added db_version parameter
* 6f30c51 Added script to clean taxonomy files when no processing
* d574275 Added list of classifiers for preparing databases (RDP, QIIME, and DADA2 by default)
* 1619919 Added RDP memory as parameter
    

## `Changes`

* 4a9408188435df1e3c2a146e8dece978448a79b0 R scripts linting
* bdb8a0e20af0541dbc465854d67f0c20fe812305 Changed R to python script for derep and merge taxonomy
* c79db5a a467bc7 Updated python env and container to 3.12.3
* 991605e Replaced `numbers_species` and `numbers_genus` by a dict `{'Species': 2, 'Genus': 4}`
* 9920ea4 Use rdp_classifier instead of rdptools
* 7c32765 Updated tax_formatting.py to work with [Greengenes2](https://greengenes2.ucsd.edu/)

## `Fixes`

* d1d3860 for #42 
* 145cfd0 Fixed lineage2taxTrain.py slowness by replacing list to set (thanks @tpillone !)
* 35b648c Fixed some convergent taxa by propagating NaN to downstream ranks