### PR TITLE
Updated cutadapt parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,27 @@ qiime tools export \
 ```
 
 * Prepare database 
+Example usage cases:
 
+1. Prepare greengenes database with V3-V4 primers:
 ```sh
 zamp db --fasta greengenes2/dna-sequences.fasta \
 --taxonomy greengenes2/taxonomy.tsv --name greengenes2 \
 --fw-primer CCTACGGGNGGCWGCAG --rv-primer GACTACHVGGGTATCTAATCC \
 -o greengenes2
+```
+
+2. Prepare fungal ITS database: Fungal ITS databases (Unite v10 and Eukaryome have been verified) do not contain the adjacent 18S/28S sequences (they contain 5.8S), where some of the commonly used PCR primers lie on. Extraction of the amplified region from the database would therefore not possible. It is important to adjust the cutadapt parameters so that only the lacking primer is not required. 
+In the following example, we prepare a database for fungal ITS1 from Unite Db. In this case, the forward primer (lying of the 18S) will not be present in most sequences of Unite/Eukaryome (but the reverse primer lying on the 5.8S is present); therefore we set the forward primer as optional; the extracted sequences will start at the available 5' of the database and end at the reverse primer:
+
+```sh
+zamp db \
+--fasta sh_refs_qiime_unite_ver10_dynamic_04.04.2024.fasta \
+--taxonomy sh_taxonomy_qiime_unite_ver10_dynamic_04.04.2024.txt \
+--name unite \
+--fw-primer CYHRGYYATTTAGAGGWMSTAA --rv-primer RCKDYSTTCWTCRWYGHTGB \
+--minlen 50 --maxlen 900  --amplicon ITS \
+--cutadapt_args_fw "optional"
 ```
 
 ### Run with prepared database

--- a/README.md
+++ b/README.md
@@ -42,9 +42,6 @@ qiime tools export \
 ```
 
 * Prepare database 
-Example usage cases:
-
-1. Prepare greengenes database with V3-V4 primers:
 ```sh
 zamp db --fasta greengenes2/dna-sequences.fasta \
 --taxonomy greengenes2/taxonomy.tsv --name greengenes2 \
@@ -52,7 +49,9 @@ zamp db --fasta greengenes2/dna-sequences.fasta \
 -o greengenes2
 ```
 
-2. Prepare fungal ITS database: Fungal ITS databases (Unite v10 and Eukaryome have been verified) do not contain the adjacent 18S/28S sequences (they contain 5.8S), where some of the commonly used PCR primers lie on. Extraction of the amplified region from the database would therefore not possible. It is important to adjust the cutadapt parameters so that only the lacking primer is not required. 
+**Fungal ITS databases**
+
+Fungal ITS databases (Unite v10 and Eukaryome have been verified) do not contain the adjacent 18S/28S sequences (they contain 5.8S), where some of the commonly used PCR primers lie on. Extraction of the amplified region from the database would therefore not possible. It is important to adjust the cutadapt parameters so that only the lacking primer is not required. 
 In the following example, we prepare a database for fungal ITS1 from Unite Db. In this case, the forward primer (lying of the 18S) will not be present in most sequences of Unite/Eukaryome (but the reverse primer lying on the 5.8S is present); therefore we set the forward primer as optional; the extracted sequences will start at the available 5' of the database and end at the reverse primer:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ zamp db \
 --taxonomy sh_taxonomy_qiime_unite_ver10_dynamic_04.04.2024.txt \
 --name unite \
 --fw-primer CYHRGYYATTTAGAGGWMSTAA --rv-primer RCKDYSTTCWTCRWYGHTGB \
---minlen 50 --maxlen 900  --amplicon ITS \
+--minlen 50 --maxlen 900 \
 --cutadapt_args_fw "optional"
 ```
 
@@ -93,7 +93,7 @@ zamp insilico -i zamp/data/bacteria-accs.txt \
 zamp insilico -i zamp/data/fungi-taxa.txt \
 -db unite_db_v10 \ 
 --fw-primer CYHRGYYATTTAGAGGWMSTAA --rv-primer RCKDYSTTCWTCRWYGHTGB \
---minlen 50 --maxlen 900  --amplicon ITS
+--minlen 50 --maxlen 900
 ```
 
 3. Using a query term. In this example, 100 assemblies will be downloaded per taxon (`nb 100`) including non-reference assemblies (`not-only-ref`):

--- a/zamp/DBprocess.Snakefile
+++ b/zamp/DBprocess.Snakefile
@@ -51,6 +51,8 @@ RV_PRIMER = config.args.rv_primer
 COV = config.args.ampcov
 MAXLEN = config.args.maxlen
 MINLEN = config.args.minlen
+FW_OTHER = config.args.cutadapt_args_fw
+RV_OTHER = config.args.cutadapt_args_rv
 
 AMPLICON = config.args.amplicon
 ADAPTER = ""
@@ -61,12 +63,7 @@ if FW_PRIMER and RV_PRIMER:
     RV_PRIMER_COMPL = Seq.reverse_complement(Seq(RV_PRIMER))
     FW_COV = round(FW_LEN * COV)
     RV_COV = round(RV_LEN * COV)
-    if AMPLICON == "16S":
-        ADAPTER = (
-            f"{FW_PRIMER};min_overlap={FW_COV}...{RV_PRIMER_COMPL};min_overlap={RV_COV}"
-        )
-    else:
-        ADAPTER = f"{FW_PRIMER};min_overlap={FW_COV};optional...{RV_PRIMER_COMPL};min_overlap={RV_COV}"
+    ADAPTER = f"{FW_PRIMER};min_overlap={FW_COV};{FW_OTHER}...{RV_PRIMER_COMPL};min_overlap={RV_COV};{RV_OTHER}"
 
 
 ## When using singularity

--- a/zamp/DBprocess.Snakefile
+++ b/zamp/DBprocess.Snakefile
@@ -54,7 +54,6 @@ MINLEN = config.args.minlen
 FW_OTHER = config.args.cutadapt_args_fw
 RV_OTHER = config.args.cutadapt_args_rv
 
-AMPLICON = config.args.amplicon
 ADAPTER = ""
 if FW_PRIMER and RV_PRIMER:
     FW_PRIMER_COMPL = Seq.reverse_complement(Seq(FW_PRIMER))

--- a/zamp/Insilico_taxa_assign.Snakefile
+++ b/zamp/Insilico_taxa_assign.Snakefile
@@ -73,7 +73,6 @@ COV = config.args.ampcov
 MAXLEN = config.args.maxlen
 MINLEN = config.args.minlen
 
-AMPLICON = config.args.amplicon
 ADAPTER = ""
 if FW_PRIMER and RV_PRIMER:
     FW_PRIMER_COMPL = Seq.reverse_complement(Seq(FW_PRIMER))
@@ -82,12 +81,7 @@ if FW_PRIMER and RV_PRIMER:
     RV_PRIMER_COMPL = Seq.reverse_complement(Seq(RV_PRIMER))
     FW_COV = round(FW_LEN * COV)
     RV_COV = round(RV_LEN * COV)
-    if AMPLICON == "16S":
-        ADAPTER = (
-            f"{FW_PRIMER};min_overlap={FW_COV}...{RV_PRIMER_COMPL};min_overlap={RV_COV}"
-        )
-    else:
-        ADAPTER = f"{FW_PRIMER};min_overlap={FW_COV};optional...{RV_PRIMER_COMPL};min_overlap={RV_COV}"
+    ADAPTER = f"{FW_PRIMER};min_overlap={FW_COV}...{RV_PRIMER_COMPL};min_overlap={RV_COV}"
 
 ## Replace empty tax
 REPL_EMPTY = config.args.replace_empty

--- a/zamp/Snakefile
+++ b/zamp/Snakefile
@@ -1,3 +1,4 @@
+from Bio.Seq import Seq
 # config file
 include: os.path.join("rules", "0_preprocessing", "functions.smk")
 
@@ -63,6 +64,7 @@ TRIM = config.args.trim
 OVERLAP = config.args.min_overlap
 FW_PRIMER = config.args.fw_primer
 RV_PRIMER = config.args.rv_primer
+RV_PRIMER_COMPL = Seq.reverse_complement(Seq(RV_PRIMER))
 
 ## Merged sequences args
 MINLEN = config.args.minlen

--- a/zamp/Snakefile
+++ b/zamp/Snakefile
@@ -60,7 +60,6 @@ PAIRING = {
 DENOISER = config.args.denoiser
 ## Primers args
 TRIM = config.args.trim
-AMPLICON = config.args.amplicon
 OVERLAP = config.args.min_overlap
 FW_PRIMER = config.args.fw_primer
 RV_PRIMER = config.args.rv_primer

--- a/zamp/rules/1_2_DADA2_ASVs/1_cutadapt_trim.rules
+++ b/zamp/rules/1_2_DADA2_ASVs/1_cutadapt_trim.rules
@@ -32,8 +32,22 @@ rule cutadapt_trim_paired:
         forward_primer=FW_PRIMER,
         reverse_primer=RV_PRIMER,
     threads: 1
-    script:
-        "scripts/1_cutadapt_paired.py"
+    shell:
+        """
+        cutadapt \
+        --cores {threads} \
+        --error-rate 0.1 \
+        --times 1 \
+        --overlap 3 \
+        -o {output.R1_trimmed_reads} \
+        -p {output.R2_trimmed_reads} \
+        -g '{params.forward_primer}' \
+        -G '{params.reverse_primer}' \
+        --match-read-wildcards \
+        --discard-untrimmed \
+        {input.R1_raw_reads} \
+        {input.R2_raw_reads} > {log}
+        """
 
 
 rule cutadapt_trim_single:
@@ -59,6 +73,20 @@ rule cutadapt_trim_single:
     params:
         forward_primer=FW_PRIMER,
         reverse_primer=RV_PRIMER,
+        reverse_primer_compl=RV_PRIMER_COMPL,
     threads: 1
-    script:
-        "scripts/1_cutadapt_single.py"
+    shell:
+        """
+        cutadapt \
+        --cores {threads} \
+        --error-rate 0.1 \
+        --times 1 \
+        --overlap 3 \
+        -o {output.R1_trimmed_reads} \
+        -g '{params.forward_primer}' \
+        -a '{params.reverse_primer_compl}' \
+        --match-read-wildcards \
+        --discard-untrimmed \
+        {input[R1_raw_reads]} > {log}
+        """
+

--- a/zamp/rules/1_2_DADA2_ASVs/1_cutadapt_trim.rules
+++ b/zamp/rules/1_2_DADA2_ASVs/1_cutadapt_trim.rules
@@ -29,7 +29,6 @@ rule cutadapt_trim_paired:
             dir.logs, "{denoiser}", "1a_trimmed_primers", "{sample}_trimmed_paired.txt"
         ),
     params:
-        amplicon_type=AMPLICON,
         forward_primer=FW_PRIMER,
         reverse_primer=RV_PRIMER,
     threads: 1
@@ -58,7 +57,6 @@ rule cutadapt_trim_single:
             dir.logs, "{denoiser}", "1a_trimmed_primers", "{sample}_trimmed_single.txt"
         ),
     params:
-        amplicon_type=AMPLICON,
         forward_primer=FW_PRIMER,
         reverse_primer=RV_PRIMER,
     threads: 1

--- a/zamp/rules/1_2_DADA2_ASVs/scripts/1_cutadapt_paired.py
+++ b/zamp/rules/1_2_DADA2_ASVs/scripts/1_cutadapt_paired.py
@@ -1,41 +1,20 @@
 from Bio.Seq import Seq
 from snakemake import shell
 
-if snakemake.params['amplicon_type'] == "ITS":
-    print("ITS Trimming")
-    forward_primer_compl = Seq.reverse_complement(Seq(snakemake.params['forward_primer']))
-    reverse_primer_compl = Seq.reverse_complement(Seq(snakemake.params['reverse_primer']))
-    shell("""cutadapt \
-    --cores {snakemake.threads} \
-    --error-rate 0.1 \
-    --times 2 \
-    --overlap 3 \
-    -o {snakemake.output[R1_trimmed_reads]} \
-    -p {snakemake.output[R2_trimmed_reads]} \
-    -g '{snakemake.params[forward_primer]}' \
-    -a '{reverse_primer_compl}' \
-    -G '{snakemake.params[reverse_primer]}' \
-    -A '{forward_primer_compl}' \
-    --match-read-wildcards \
-    --discard-untrimmed \
-    {snakemake.input[R1_raw_reads]} \
-    {snakemake.input[R2_raw_reads]} >> {snakemake.log[0]}""")
-
-elif snakemake.params['amplicon_type'] == "16S":
-    print("16S Trimming")
-    shell("""cutadapt \
-    --cores {snakemake.threads} \
-    --error-rate 0.1 \
-    --times 1 \
-    --overlap 3 \
-    -o {snakemake.output[R1_trimmed_reads]} \
-    -p {snakemake.output[R2_trimmed_reads]} \
-    -g '{snakemake.params[forward_primer]}' \
-    -G '{snakemake.params[reverse_primer]}' \
-    --match-read-wildcards \
-    --discard-untrimmed \
-    {snakemake.input[R1_raw_reads]} \
-    {snakemake.input[R2_raw_reads]} >> {snakemake.log[0]}""")
+print("Primer Trimming")
+shell("""cutadapt \
+--cores {snakemake.threads} \
+--error-rate 0.1 \
+--times 1 \
+--overlap 3 \
+-o {snakemake.output[R1_trimmed_reads]} \
+-p {snakemake.output[R2_trimmed_reads]} \
+-g '{snakemake.params[forward_primer]}' \
+-G '{snakemake.params[reverse_primer]}' \
+--match-read-wildcards \
+--discard-untrimmed \
+{snakemake.input[R1_raw_reads]} \
+{snakemake.input[R2_raw_reads]} >> {snakemake.log[0]}""")
 
 
 

--- a/zamp/rules/1_2_DADA2_ASVs/scripts/1_cutadapt_single.py
+++ b/zamp/rules/1_2_DADA2_ASVs/scripts/1_cutadapt_single.py
@@ -2,35 +2,19 @@ from Bio.Seq import Seq
 from snakemake import shell
 
 
-if snakemake.params['amplicon_type'] == "ITS":
-    print("ITS Trimming")
-    forward_primer_compl = Seq.reverse_complement(Seq(snakemake.params['forward_primer']))
-    shell("""cutadapt \
-    --cores {snakemake.threads} \
-    --error-rate 0.1 \
-    --times 2 \
-    --overlap 3 \
-    -o {snakemake.output[R1_trimmed_reads]} \
-    -g '{snakemake.params[forward_primer]}' \
-    -a '{reverse_primer_compl}' \
-    --match-read-wildcards \
-    --discard-untrimmed \
-    {snakemake.input[R1_raw_reads]} >> {snakemake.log[0]}""")
-
-elif snakemake.params['amplicon_type'] == "16S":
-    print("16S Trimming")
-    reverse_primer_compl = Seq.reverse_complement(Seq(snakemake.params['reverse_primer']))
-    shell("""cutadapt \
-    --cores {snakemake.threads} \
-    --error-rate 0.1 \
-    --times 1 \
-    --overlap 3 \
-    -o {snakemake.output[R1_trimmed_reads]} \
-    -g '{snakemake.params[forward_primer]}' \
-    -a '{reverse_primer_compl}' \
-    --match-read-wildcards \
-    --discard-untrimmed \
-    {snakemake.input[R1_raw_reads]}  >> {snakemake.log[0]}""")
+print("Primer Trimming")
+reverse_primer_compl = Seq.reverse_complement(Seq(snakemake.params['reverse_primer']))
+shell("""cutadapt \
+--cores {snakemake.threads} \
+--error-rate 0.1 \
+--times 1 \
+--overlap 3 \
+-o {snakemake.output[R1_trimmed_reads]} \
+-g '{snakemake.params[forward_primer]}' \
+-a '{reverse_primer_compl}' \
+--match-read-wildcards \
+--discard-untrimmed \
+{snakemake.input[R1_raw_reads]}  >> {snakemake.log[0]}""")
 
 
 

--- a/zamp/utils.py
+++ b/zamp/utils.py
@@ -313,6 +313,18 @@ def db_options(func):
             show_default=True,
         ),
         click.option(
+            "--cutadapt_args_fw",
+            type=str,
+            default="",
+            help="Additional cutadapt arguments for forward primer",
+        ),
+        click.option(
+            "--cutadapt_args_rv",
+            type=str,
+            default="",
+            help="Additional cutadapt arguments for reverse primer",
+        ),
+        click.option(
             "--rdp-mem",
             type=str,
             help="Maximum RAM for RDP training",

--- a/zamp/utils.py
+++ b/zamp/utils.py
@@ -248,13 +248,6 @@ def db_options(func):
             required=True,
         ),
         click.option(
-            "--amplicon",
-            type=click.Choice(["16S", "ITS"]),
-            default="16S",
-            help="Choose 16S or ITS for primer trimming",
-            show_default=True,
-        ),
-        click.option(
             "--name",
             type=str,
             help="Comma seperated list of database names",
@@ -405,13 +398,6 @@ def run_options(func):
             "--trim/--no-trim",
             default=True,
             help="Trim primers or not",
-            show_default=True,
-        ),
-        click.option(
-            "--amplicon",
-            type=click.Choice(["16S", "ITS"]),
-            default="16S",
-            help="Choose 16S or ITS for primer trimming",
             show_default=True,
         ),
         click.option(
@@ -651,13 +637,6 @@ def insilico_options(func):
             type=click.Choice(["simulate", "in-silico"], case_sensitive=False),
             help="Tool for in silico PCR",
             default="in-silico",
-            show_default=True,
-        ),
-        click.option(
-            "--amplicon",
-            type=click.Choice(["16S", "ITS"]),
-            default="16S",
-            help="Choose 16S or ITS for primer trimming",
             show_default=True,
         ),
         click.option(


### PR DESCRIPTION
# Summary
I added a new parameter to be able to provide additional cutadapt arguments for the forward and/or reverse primer.
This is needed for the ITS database preparation, because the presence of the primer needs to be set as "optional" according to their presence/absence on the DB.
On the other hand, I remove this optional primer trimming in zamp run and zamp insilico, because the read data should always contain primers and be trimmed.

In zamp run, cutadapt is called directly on the rules file, and not as an script.

I added usage example to prepare a fungal ITS database.

# Details

## `Additions`

* 38ac9f7c18dec29e2fce5cfb7203d894b86795f2 Add parameter for additional cutadapt arguments for forward and reverse primers.
* af41bee8dd1903dc558cef0a9a0666bffcf15c17 Update docu with usage cases for zamp db

## `Changes`

* 2e0dcc0b37367533abcbfbae46d799db6659986e cutadapt called from snakemake rules files; not as a script.

## `Fixes`

* b0dd769f812c7b561f8d27446daf28da6df31508 Remove optional primer trimming in insilico and run module. Drop amplicon parameter.